### PR TITLE
Using reprint for deep copy of unexported struct fields

### DIFF
--- a/stats.go
+++ b/stats.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"sync"
 
-	"github.com/jinzhu/copier"
+	"github.com/qdm12/reprint"
 )
 
 const NOT_SUPPORTED = "N/S"
@@ -653,5 +653,5 @@ func ToStatsDeep(input Stats) Stats {
 
 // DeepCopy Make a deep copy from src into dst. src, dst both should be pointer
 func DeepCopy(dst interface{}, src interface{}) error {
-	return copier.CopyWithOption(dst, src, copier.Option{DeepCopy: true, IgnoreEmpty: false})
+	return reprint.FromTo(src, dst)
 }


### PR DESCRIPTION
Deep copy skipped unexported fields. Switched to using reprint that copied unexported struct fields