### PR TITLE
Support list for tls-authenticate-client.

### DIFF
--- a/asconfig/singular_plural.go
+++ b/asconfig/singular_plural.go
@@ -34,6 +34,7 @@ var singularToPlural = map[string]string{
 	"tls-mesh-seed-address-port":   "tls-mesh-seed-address-ports",
 	"tls-node":                     "tls-nodes",
 	"xdr-remote-datacenter":        "xdr-remote-datacenters",
+	"tls-authenticate-client":      "tls-authenticate-clients",
 }
 
 var pluralToSingular map[string]string = map[string]string{}

--- a/asconfig/utils.go
+++ b/asconfig/utils.go
@@ -586,7 +586,7 @@ func isListField(key string) (bool, string) {
 	case "file", "address", "tls-address", "access-address", "mount",
 		"tls-access-address", "alternate-access-address",
 		"tls-alternate-access-address", "role-query-pattern",
-		"xdr-remote-datacenter", "multicast-group":
+		"xdr-remote-datacenter", "multicast-group", "tls-authenticate-client":
 		return true, ""
 	default:
 		return false, ""
@@ -849,7 +849,11 @@ func toConf(input map[string]interface{}) Conf {
 				case string:
 					temp := make([]string, len(v))
 					for i, s := range v {
-						temp[i] = s.(string)
+						if boolVal, isBool := s.(bool); isBool && isSpecialStringField(k) {
+							temp[i] = strconv.FormatBool(boolVal)
+						} else {
+							temp[i] = s.(string)
+						}
 					}
 					result[k] = temp
 				case map[string]interface{}, lib.Stats:
@@ -881,7 +885,11 @@ func toConf(input map[string]interface{}) Conf {
 
 		case bool:
 			if isSpecialStringField(k) {
-				result[k] = strconv.FormatBool(v)
+				if ok, _ := isListField(k); ok {
+					result[k] = []string{strconv.FormatBool(v)}
+				} else {
+					result[k] = strconv.FormatBool(v)
+				}
 			} else {
 				result[k] = v
 			}


### PR DESCRIPTION
This PR is to support multiple values for **tls-authenticate-client** field.
Just marked **tls-authenticate-client** field as a list.
**tls-authenticate-client** may have "false" value and parser will convert this value into boolean. If we see this we will convert it back to String. This behavior was just copied from existing tls-authenticate-client behavior.
see details in usage of function **isSpecialStringField(string)** [utils.go]

There will be another PR to [aerospike-kubernetes-operator](https://github.com/aerospike/aerospike-kubernetes-operator) to support it in CRD schema.