### PR TITLE
Aerospike client upgrade

### DIFF
--- a/deployment/aeroinfo.go
+++ b/deployment/aeroinfo.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/aerospike/aerospike-management-lib/info"
-	aero "github.com/ashishshinde/aerospike-client-go"
+	aero "github.com/ashishshinde/aerospike-client-go/v5"
 	log "github.com/inconshreveable/log15"
 )
 

--- a/deployment/cluster.go
+++ b/deployment/cluster.go
@@ -10,7 +10,7 @@ import (
 	"github.com/aerospike/aerospike-management-lib/asconfig"
 	log "github.com/inconshreveable/log15"
 
-	aero "github.com/ashishshinde/aerospike-client-go"
+	aero "github.com/ashishshinde/aerospike-client-go/v5"
 )
 
 // cluster represents an aerospike cluster

--- a/deployment/cluster.go
+++ b/deployment/cluster.go
@@ -523,6 +523,9 @@ func (c *cluster) infoCmd(hostID, cmd string) (map[string]string, error) {
 
 	info, err := n.asConnInfo.asinfo.RequestInfo(cmd)
 	lg.Debug("finished running InfoCmd", log.Ctx{"err": err})
+
+	lg.Debug("@@@@@ finished running InfoCmd", log.Ctx{"err": err, "info": info})
+
 	if err != nil {
 		return nil, err
 	}

--- a/deployment/cluster.go
+++ b/deployment/cluster.go
@@ -524,8 +524,6 @@ func (c *cluster) infoCmd(hostID, cmd string) (map[string]string, error) {
 	info, err := n.asConnInfo.asinfo.RequestInfo(cmd)
 	lg.Debug("finished running InfoCmd", log.Ctx{"err": err})
 
-	lg.Debug("@@@@@ finished running InfoCmd", log.Ctx{"err": err, "info": info})
-
 	if err != nil {
 		return nil, err
 	}

--- a/deployment/deployment.go
+++ b/deployment/deployment.go
@@ -4,7 +4,7 @@ import (
 	"net"
 	"strconv"
 
-	aero "github.com/ashishshinde/aerospike-client-go"
+	aero "github.com/ashishshinde/aerospike-client-go/v5"
 	"github.com/aerospike/aerospike-management-lib/system"
 	log "github.com/inconshreveable/log15"
 	"golang.org/x/crypto/ssh"

--- a/deployment/host.go
+++ b/deployment/host.go
@@ -6,7 +6,7 @@ import (
 	log "github.com/inconshreveable/log15"
 	"golang.org/x/crypto/ssh"
 
-	aero "github.com/ashishshinde/aerospike-client-go"
+	aero "github.com/ashishshinde/aerospike-client-go/v5"
 
 	"github.com/aerospike/aerospike-management-lib/info"
 	"github.com/aerospike/aerospike-management-lib/system"

--- a/info/as_parser.go
+++ b/info/as_parser.go
@@ -1,6 +1,7 @@
 package info
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -181,8 +182,9 @@ func (info *AsInfo) doInfo(commands ...string) (map[string]string, error) {
 
 		aerr := info.conn.Login(info.policy)
 		if aerr != nil {
-			if _, ok := aerr.(AerospikeError); ok {
-				return nil, fmt.Errorf("failed to authenticate user `%s` in aerospike server: %v", info.policy.User, aerr.(AerospikeError).ResultCode())
+			ae := &aero.AerospikeError{}
+			if errors.As(err, &ae) {
+				return nil, fmt.Errorf("failed to authenticate user `%s` in aerospike server: %v", info.policy.User, ae.ResultCode)
 			}
 			return nil, fmt.Errorf("failed to authenticate user `%s` in aerospike server: %v", info.policy.User, aerr)
 		}

--- a/info/as_parser.go
+++ b/info/as_parser.go
@@ -181,7 +181,10 @@ func (info *AsInfo) doInfo(commands ...string) (map[string]string, error) {
 
 		aerr := info.conn.Login(info.policy)
 		if aerr != nil {
-			return nil, fmt.Errorf("failed to authenticate user `%s` in aerospike server: %v", info.policy.User, aerr.resultCode())
+			if _, ok := aerr.(AerospikeError); ok {
+				return nil, fmt.Errorf("failed to authenticate user `%s` in aerospike server: %v", info.policy.User, aerr.(AerospikeError).ResultCode())
+			}
+			return nil, fmt.Errorf("failed to authenticate user `%s` in aerospike server: %v", info.policy.User, aerr)
 		}
 		info.log.Debug("secure connection created for aerospike info")
 	}

--- a/info/as_parser.go
+++ b/info/as_parser.go
@@ -181,10 +181,7 @@ func (info *AsInfo) doInfo(commands ...string) (map[string]string, error) {
 
 		aerr := info.conn.Login(info.policy)
 		if aerr != nil {
-			if _, ok := aerr.(ast.AerospikeError); ok {
-				return nil, fmt.Errorf("failed to authenticate user `%s` in aerospike server: %v", info.policy.User, aerr.(ast.AerospikeError).ResultCode())
-			}
-			return nil, fmt.Errorf("failed to authenticate user `%s` in aerospike server: %v", info.policy.User, aerr)
+			return nil, fmt.Errorf("failed to authenticate user `%s` in aerospike server: %v", info.policy.User, aerr.resultCode())
 		}
 		info.log.Debug("secure connection created for aerospike info")
 	}

--- a/info/as_parser.go
+++ b/info/as_parser.go
@@ -11,8 +11,8 @@ import (
 	"sync"
 	"time"
 
-	aero "github.com/ashishshinde/aerospike-client-go"
-	ast "github.com/ashishshinde/aerospike-client-go/types"
+	aero "github.com/ashishshinde/aerospike-client-go/v5"
+	ast "github.com/ashishshinde/aerospike-client-go/v5/types"
 
 	lib "github.com/aerospike/aerospike-management-lib"
 	"github.com/aerospike/aerospike-management-lib/bcrypt"
@@ -179,7 +179,7 @@ func (info *AsInfo) doInfo(commands ...string) (map[string]string, error) {
 			return nil, fmt.Errorf("failed to create secure connection for aerospike info: %v", err)
 		}
 
-		aerr := info.conn.Authenticate(info.policy.User, info.policy.Password)
+		/*aerr := info.conn.Authenticate(info.policy.User, info.policy.Password)
 		if aerr != nil {
 			if _, ok := aerr.(ast.AerospikeError); ok {
 				return nil, fmt.Errorf("failed to authenticate user `%s` in aerospike server: %v", info.policy.User, aerr.(ast.AerospikeError).ResultCode())
@@ -187,6 +187,7 @@ func (info *AsInfo) doInfo(commands ...string) (map[string]string, error) {
 			return nil, fmt.Errorf("failed to authenticate user `%s` in aerospike server: %v", info.policy.User, aerr)
 		}
 		info.log.Debug("secure connection created for aerospike info")
+		*/
 	}
 
 	var deadline time.Time
@@ -195,7 +196,7 @@ func (info *AsInfo) doInfo(commands ...string) (map[string]string, error) {
 	}
 	info.conn.SetTimeout(deadline, asTimeout)
 
-	result, err := aero.RequestInfo(info.conn, commands...)
+	result, err := info.conn.RequestInfo(commands...)
 	if err != nil {
 		info.log.Debug("failed to run aerospike info command", log.Ctx{"err": err})
 		if err == io.EOF {

--- a/info/as_parser.go
+++ b/info/as_parser.go
@@ -179,7 +179,7 @@ func (info *AsInfo) doInfo(commands ...string) (map[string]string, error) {
 			return nil, fmt.Errorf("failed to create secure connection for aerospike info: %v", err)
 		}
 
-		/*aerr := info.conn.Authenticate(info.policy.User, info.policy.Password)
+		aerr := info.conn.Login(info.policy)
 		if aerr != nil {
 			if _, ok := aerr.(ast.AerospikeError); ok {
 				return nil, fmt.Errorf("failed to authenticate user `%s` in aerospike server: %v", info.policy.User, aerr.(ast.AerospikeError).ResultCode())
@@ -187,7 +187,6 @@ func (info *AsInfo) doInfo(commands ...string) (map[string]string, error) {
 			return nil, fmt.Errorf("failed to authenticate user `%s` in aerospike server: %v", info.policy.User, aerr)
 		}
 		info.log.Debug("secure connection created for aerospike info")
-		*/
 	}
 
 	var deadline time.Time

--- a/info/test/parser_test.go
+++ b/info/test/parser_test.go
@@ -9,7 +9,7 @@ import (
 
 	"golang.org/x/crypto/ssh"
 
-	aero "github.com/ashishshinde/aerospike-client-go"
+	aero "github.com/ashishshinde/aerospike-client-go/v5"
 
 	lib "github.com/aerospike/aerospike-management-lib"
 	"github.com/aerospike/aerospike-management-lib/info"


### PR DESCRIPTION
Upgraded to use Aerospike go client 5.2+ 
 - required for authenticating correctly with 5.6.+ Aerospike server instances.
 - allows quotas to be set