### PR TITLE
export method to get list of nodes that are quiesced

### DIFF
--- a/deployment/aeroinfo.go
+++ b/deployment/aeroinfo.go
@@ -39,6 +39,16 @@ func InfoQuiesceUndo(log logr.Logger, policy *aero.ClientPolicy, allHosts []*Hos
 	return c.InfoQuiesceUndo(getHostIDsFromHostConns(allHosts))
 }
 
+// GetQuiescedNodes returns a list of node hostIDs of all nodes that are pending_quiesce=true.
+func GetQuiescedNodes(log logr.Logger, policy *aero.ClientPolicy, allHosts []*HostConn) ([]string, error) {
+	c, err := newCluster(log, policy, allHosts, allHosts)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create a cluster copy for running aeroinfo: %v", err)
+	}
+
+	return c.getQuiescedNodes(getHostIDsFromHostConns(allHosts))
+}
+
 // SetMigrateFillDelay sets the given migrate-fill-delay on all the given cluster nodes
 func SetMigrateFillDelay(log logr.Logger, policy *aero.ClientPolicy, allHosts []*HostConn, migrateFillDelay int) error {
 	c, err := newCluster(log, policy, allHosts, allHosts)

--- a/deployment/cluster.go
+++ b/deployment/cluster.go
@@ -601,7 +601,7 @@ func (c *cluster) infoClusterStablePerNamespace(hostIDs, removedNamespaces []str
 	return nil
 }
 
-func (c *cluster) GetQuiescedNodes(hostIDs []string) ([]string, error) {
+func (c *cluster) getQuiescedNodes(hostIDs []string) ([]string, error) {
 	var quiescedNodes []string
 
 	namespaces, err := c.getClusterNamespaces(hostIDs)
@@ -676,7 +676,7 @@ func (c *cluster) InfoQuiesceUndo(hostIDs []string) error {
 	}
 
 	// Fetching quiesced Nodes
-	quiescedNodes, err := c.GetQuiescedNodes(hostIDs)
+	quiescedNodes, err := c.getQuiescedNodes(hostIDs)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The previous PR, https://github.com/aerospike/aerospike-management-lib/pull/34, exported the `getQuiescedNodes` on the wrong object since the `cluster` object is internal.  This PR fixes that by exposing `GetQuiescedNodes` from the `deployment` package.

https://aerospike.atlassian.net/browse/DBAASDEV-1073