### PR TITLE
refactor: Remove version argument from AsConfig constructor

### DIFF
--- a/asconfig/asconfig.go
+++ b/asconfig/asconfig.go
@@ -11,12 +11,10 @@ import (
 type AsConfig struct {
 	log      logr.Logger
 	baseConf *Conf
-	version  string
 }
 
-func New(log logr.Logger, version string, bconf *Conf) *AsConfig {
+func New(log logr.Logger, bconf *Conf) *AsConfig {
 	return &AsConfig{
-		version:  version,
 		baseConf: bconf,
 		log:      log,
 	}
@@ -33,14 +31,13 @@ type ValidationErr struct {
 
 // NewMapAsConfig creates AsConfig. Typically an unmarshalled yaml file is passed in
 func NewMapAsConfig(
-	log logr.Logger, version string, configMap map[string]interface{},
+	log logr.Logger, configMap map[string]interface{},
 ) (*AsConfig, error) {
 	baseConf := newMap(log, configMap)
 
 	return &AsConfig{
 		log:      log,
 		baseConf: &baseConf,
-		version:  version,
 	}, nil
 }
 
@@ -87,7 +84,7 @@ func FromConfFile(log logr.Logger, version string, in io.Reader) (*AsConfig, err
 		return nil, err
 	}
 
-	return NewMapAsConfig(log, version, configMap)
+	return NewMapAsConfig(log, configMap)
 }
 
 // IsSupportedVersion returns true if version supported else false

--- a/asconfig/asconfig.go
+++ b/asconfig/asconfig.go
@@ -9,8 +9,8 @@ import (
 
 // AsConfig is wrapper over Conf
 type AsConfig struct {
-	log      logr.Logger
 	baseConf *Conf
+	log      logr.Logger
 }
 
 func New(log logr.Logger, bconf *Conf) *AsConfig {

--- a/asconfig/asconfig_test.go
+++ b/asconfig/asconfig_test.go
@@ -22,13 +22,11 @@ func (s *AsConfigTestSuite) SetupTest() {
 func (s *AsConfigTestSuite) TestAsConfigGetFlatMap() {
 	testCases := []struct {
 		name     string
-		version  string
 		inputMap map[string]interface{}
 		expected *Conf
 	}{
 		{
 			"namespace context",
-			"7.0.0",
 			map[string]interface{}{
 				"namespaces": []map[string]interface{}{
 					{
@@ -56,7 +54,6 @@ func (s *AsConfigTestSuite) TestAsConfigGetFlatMap() {
 		},
 		{
 			"xdr 4.9 context",
-			"4.9.0",
 			map[string]interface{}{
 				"xdr": map[string]interface{}{
 					"datacenters": []map[string]interface{}{
@@ -81,7 +78,7 @@ func (s *AsConfigTestSuite) TestAsConfigGetFlatMap() {
 		s.Run(tc.name, func() {
 			logger := logr.Discard()
 
-			asConfig, err := NewMapAsConfig(logger, tc.version, tc.inputMap)
+			asConfig, err := NewMapAsConfig(logger, tc.inputMap)
 			actual := asConfig.GetFlatMap()
 
 			s.Assert().Nil(err)
@@ -93,13 +90,11 @@ func (s *AsConfigTestSuite) TestAsConfigGetFlatMap() {
 func (s *AsConfigTestSuite) TestAsConfigGetExpandMap() {
 	testCases := []struct {
 		name     string
-		version  string
 		inputMap map[string]interface{}
 		expected Conf
 	}{
 		{
 			"namespace context",
-			"7.0.0",
 			map[string]interface{}{
 				"logging": []Conf{
 					{
@@ -367,7 +362,7 @@ func (s *AsConfigTestSuite) TestAsConfigGetExpandMap() {
 		s.Run(tc.name, func() {
 			logger := logr.Discard()
 
-			asConfig, err := NewMapAsConfig(logger, tc.version, tc.inputMap)
+			asConfig, err := NewMapAsConfig(logger, tc.inputMap)
 			actual := asConfig.ToMap()
 
 			s.Assert().Nil(err)

--- a/test/generate_e2e_test.go
+++ b/test/generate_e2e_test.go
@@ -57,11 +57,10 @@ func (s *GenerateE2eTestSuite) TestGenerate() {
 	genConfWithDefaults, err := asconfig.GenerateConf(logr.Discard(), asinfo, false)
 	s.Assert().Nil(err)
 
-	asconf, err := asconfig.NewMapAsConfig(logr.Discard(), genConf.Version, genConf.Conf)
+	asconf, err := asconfig.NewMapAsConfig(logr.Discard(), genConf.Conf)
 	s.Assert().Nil(err)
 	asconfWithDefaults, err := asconfig.NewMapAsConfig(
 		logr.Discard(),
-		genConfWithDefaults.Version,
 		genConfWithDefaults.Conf,
 	)
 	s.Assert().Nil(err)
@@ -76,11 +75,10 @@ func (s *GenerateE2eTestSuite) TestGenerate() {
 	genConfWithDefaults2, err := asconfig.GenerateConf(logr.Discard(), asinfo2, false)
 	s.Assert().Nil(err)
 
-	asconf2, err := asconfig.NewMapAsConfig(logr.Discard(), genConf2.Version, genConf2.Conf)
+	asconf2, err := asconfig.NewMapAsConfig(logr.Discard(), genConf2.Conf)
 	s.Assert().Nil(err)
 	asconfWithDefaults2, err := asconfig.NewMapAsConfig(
 		logr.Discard(),
-		genConfWithDefaults2.Version,
 		genConfWithDefaults2.Conf,
 	)
 	s.Assert().Nil(err)


### PR DESCRIPTION
I could not find any use for the version flag as part of the struct. We could instead leave it as is an allow IsValid to use the version member instead of requiring an argument, but I think this is more clear about how the version is intended to be used