### PR TITLE
fix: connection timeout and not authenticated requests

### DIFF
--- a/info/as_parser_test.go
+++ b/info/as_parser_test.go
@@ -200,8 +200,8 @@ func TestNewAsInfo_ConnectionError(t *testing.T) {
 		t.Errorf("Expected nil response, got %v", r)
 	}
 
-	if errors.Is(acutalErr, expectedErr) == false {
-		t.Errorf("Expected error %v, got %v", expectedErr, acutalErr)
+	if errors.Is(actualErr, expectedErr) == false {
+		t.Errorf("Expected error %v, got %v", expectedErr, actualErr)
 	}
 }
 

--- a/info/as_parser_test.go
+++ b/info/as_parser_test.go
@@ -194,7 +194,7 @@ func TestNewAsInfo_ConnectionError(t *testing.T) {
 
 	asinfo := NewAsInfoWithConnFactory(logr.Discard(), host, policy, mockConnFact)
 
-	r, acutalErr := asinfo.RequestInfo("connection will fail")
+	r, actualErr := asinfo.RequestInfo("connection will fail")
 
 	if r != nil {
 		t.Errorf("Expected nil response, got %v", r)

--- a/info/as_parser_test.go
+++ b/info/as_parser_test.go
@@ -1,6 +1,7 @@
 package info
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -181,4 +182,52 @@ func (s *AsParserTestSuite) TestAsInfoRequestInfoXDR5() {
 
 func TestAsParserTestSuite(t *testing.T) {
 	suite.Run(t, new(AsParserTestSuite))
+}
+
+func TestNewAsInfo_ConnectionError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockConnFact := NewMockConnectionFactory(ctrl)
+	expectedErr := &aero.AerospikeError{ResultCode: 1}
+	policy := &aero.ClientPolicy{}
+	host := &aero.Host{}
+	mockConnFact.EXPECT().NewConnection(policy, host).Return(nil, expectedErr).AnyTimes()
+
+	asinfo := NewAsInfoWithConnFactory(logr.Discard(), host, policy, mockConnFact)
+
+	r, acutalErr := asinfo.RequestInfo("connection will fail")
+
+	if r != nil {
+		t.Errorf("Expected nil response, got %v", r)
+	}
+
+	if errors.Is(acutalErr, expectedErr) == false {
+		t.Errorf("Expected error %v, got %v", expectedErr, acutalErr)
+	}
+}
+
+func TestNewAsInfo_NotAuthenticatedError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockConnFact := NewMockConnectionFactory(ctrl)
+	mockConn := NewMockConnection(ctrl)
+	policy := &aero.ClientPolicy{}
+	host := &aero.Host{}
+	mockConnFact.EXPECT().NewConnection(policy, host).Return(mockConn, nil).AnyTimes()
+	mockConn.EXPECT().IsConnected().Return(true).AnyTimes()
+	mockConn.EXPECT().Login(policy).Return(nil).AnyTimes()
+	mockConn.EXPECT().SetTimeout(gomock.Any(), time.Second*100).AnyTimes()
+	mockConn.EXPECT().Close().Return().AnyTimes()
+	mockConn.EXPECT().RequestInfo([]string{"auth will fail"}).Return(map[string]string{"ERROR:80:not authenticated": ""}, nil)
+
+	maxInfoRetries = 1 // Should be configurable
+	asinfo := NewAsInfoWithConnFactory(logr.Discard(), host, policy, mockConnFact)
+
+	r, acutalErr := asinfo.RequestInfo("auth will fail")
+
+	if r != nil {
+		t.Errorf("Expected nil response, got %v", r)
+	}
+
+	if errors.Is(acutalErr, ErrConnNotAuthenticated) == false {
+		t.Errorf("Expected error %v, got %v", ErrConnNotAuthenticated, acutalErr)
+	}
 }


### PR DESCRIPTION
Writing to `info.conn` before the `err != nil` check was causing the interface `(Connection, nil)` to be assigned. On subsequent nil checks due to the retry mechanism's `info.conn == nil` was returning `false`, and `info.conn.IsConnected()` was raising a "nil dereference error".

If a user and password are not provided and the server requires authentication, `info.conn.Login()` does not return an error.  Instead, an error is returned from the `InfoReequest()` call.

Some tests were added for these cases