### PR TITLE
DBAASDEV-1384: Export GetInfoCmd

### DIFF
--- a/deployment/aeroinfo.go
+++ b/deployment/aeroinfo.go
@@ -70,12 +70,12 @@ func GetClusterNamespaces(log logr.Logger, policy *aero.ClientPolicy,
 	return c.getClusterNamespaces(getHostIDsFromHostConns(allHosts))
 }
 
-// GetInfoStatistics returns output from 'asinfo statistics' on each node
-func GetInfoStatistics(log logr.Logger, policy *aero.ClientPolicy, allHosts []*HostConn) (InfoResults, error) {
+// GetInfoCmd returns output from a specified asinfo command for each node in the cluster
+func GetInfoCmd(log logr.Logger, policy *aero.ClientPolicy, allHosts []*HostConn, cmd string) (InfoResults, error) {
 	c, err := newCluster(log, policy, allHosts, allHosts)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create a cluster copy for running aeroinfo: %v", err)
 	}
 
-	return c.infoOnHosts(getHostIDsFromHostConns(allHosts), "statistics")
+	return c.infoOnHosts(getHostIDsFromHostConns(allHosts), cmd)
 }

--- a/deployment/aeroinfo.go
+++ b/deployment/aeroinfo.go
@@ -71,7 +71,7 @@ func GetClusterNamespaces(log logr.Logger, policy *aero.ClientPolicy,
 }
 
 // GetInfoStatistics returns output from 'asinfo statistics' on each node
-func GetInfoStatistics(log logr.Logger, policy *aero.ClientPolicy, allHosts []*HostConn) (map[string]infoResult, error) {
+func GetInfoStatistics(log logr.Logger, policy *aero.ClientPolicy, allHosts []*HostConn) (InfoResults, error) {
 	c, err := newCluster(log, policy, allHosts, allHosts)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create a cluster copy for running aeroinfo: %v", err)

--- a/deployment/aeroinfo.go
+++ b/deployment/aeroinfo.go
@@ -69,3 +69,13 @@ func GetClusterNamespaces(log logr.Logger, policy *aero.ClientPolicy,
 
 	return c.getClusterNamespaces(getHostIDsFromHostConns(allHosts))
 }
+
+// GetInfoStatistics returns output from 'asinfo statistics' on each node
+func GetInfoStatistics(log logr.Logger, policy *aero.ClientPolicy, allHosts []*HostConn) (map[string]infoResult, error) {
+	c, err := newCluster(log, policy, allHosts, allHosts)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create a cluster copy for running aeroinfo: %v", err)
+	}
+
+	return c.infoOnHosts(getHostIDsFromHostConns(allHosts), "statistics")
+}

--- a/deployment/cluster.go
+++ b/deployment/cluster.go
@@ -789,7 +789,8 @@ func (c *cluster) infoOnHosts(
 	wg.Wait()
 
 	if len(infos) != len(hostIDs) {
-		return nil, fmt.Errorf(
+		// We are still interested in the info of hosts we could get
+		return infos, fmt.Errorf(
 			"failed to fetch aerospike info `%s` for all hosts %v", cmd,
 			hostIDs,
 		)
@@ -827,7 +828,8 @@ func (c *cluster) infoCmdsOnHosts(hostIDCmdMap map[string]string) (
 	wg.Wait()
 
 	if len(infos) != len(hostIDCmdMap) {
-		return nil, fmt.Errorf(
+		// We are still interested in the info of hosts we could get
+		return infos, fmt.Errorf(
 			"failed to fetch aerospike info for all hosts %v", hostIDCmdMap,
 		)
 	}

--- a/deployment/utils.go
+++ b/deployment/utils.go
@@ -10,6 +10,8 @@ import (
 
 type infoResult map[string]string
 
+type InfoResults map[string]infoResult
+
 func (ir infoResult) toInt(key string) (int, error) {
 	val, ok := ir[key]
 	if !ok {


### PR DESCRIPTION
Hi, Josh from the Aerospike Cloud (DBaaS) team here.

I'm making this PR to fulfill a few requirements we have:

1. We want the ability to run arbitrary `asinfo` commands from our code. Exporting this `GetInfoCmd()` method will allow us to do so
2. For `IsClusterAndStable()`, we want to be able to rely on consistent error reporting to tell us why a cluster is not stable. This PR standardizes the error output in this method to always return a reason for a cluster being unstable.
3. One modification to `infoOnHosts()` and `infoCmdsOnHosts()` to return infos that we were able to fetch even if the asinfo command failed on one or more hosts. This will allow us to get info on hosts that are healthy even if part of the cluster is not.

Feel free to message me on Slack with any questions about this PR