### PR TITLE
DBAASDEV-1384 Export getInfoOnHosts

### DIFF
--- a/deployment/aeroinfo.go
+++ b/deployment/aeroinfo.go
@@ -69,3 +69,12 @@ func GetClusterNamespaces(log logr.Logger, policy *aero.ClientPolicy,
 
 	return c.getClusterNamespaces(getHostIDsFromHostConns(allHosts))
 }
+
+func GetInfoOnHosts(log logr.Logger, policy *aero.ClientPolicy, allHosts []*HostConn, cmd string) (map[string]InfoResult, error) {
+	c, err := newCluster(log, policy, allHosts, allHosts)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create a cluster copy for running aeroinfo: %v", err)
+	}
+
+	return c.infoOnHosts(getHostIDsFromHostConns(allHosts), cmd)
+}

--- a/deployment/aeroinfo.go
+++ b/deployment/aeroinfo.go
@@ -70,7 +70,8 @@ func GetClusterNamespaces(log logr.Logger, policy *aero.ClientPolicy,
 	return c.getClusterNamespaces(getHostIDsFromHostConns(allHosts))
 }
 
-func GetInfoOnHosts(log logr.Logger, policy *aero.ClientPolicy, allHosts []*HostConn, cmd string) (map[string]InfoResult, error) {
+func GetInfoOnHosts(log logr.Logger, policy *aero.ClientPolicy,
+	allHosts []*HostConn, cmd string) (map[string]InfoResult, error) {
 	c, err := newCluster(log, policy, allHosts, allHosts)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create a cluster copy for running aeroinfo: %v", err)

--- a/deployment/cluster.go
+++ b/deployment/cluster.go
@@ -770,8 +770,8 @@ func (c *cluster) infoCmd(hostID, cmd string) (map[string]string, error) {
 // infoOnHosts returns the result of running the info command on the hosts.
 func (c *cluster) infoOnHosts(
 	hostIDs []string, cmd string,
-) (map[string]infoResult, error) {
-	infos := make(map[string]infoResult) // host id to info output
+) (map[string]InfoResult, error) {
+	infos := make(map[string]InfoResult) // host id to info output
 
 	var (
 		mut sync.Mutex
@@ -796,7 +796,8 @@ func (c *cluster) infoOnHosts(
 	wg.Wait()
 
 	if len(infos) != len(hostIDs) {
-		return nil, fmt.Errorf(
+		// We are still interested in the info of hosts we could get
+		return infos, fmt.Errorf(
 			"failed to fetch aerospike info `%s` for all hosts %v", cmd,
 			hostIDs,
 		)
@@ -807,9 +808,9 @@ func (c *cluster) infoOnHosts(
 
 // infoCmdsOnHosts returns the result of running the info command on the hosts.
 func (c *cluster) infoCmdsOnHosts(hostIDCmdMap map[string]string) (
-	map[string]infoResult, error,
+	map[string]InfoResult, error,
 ) {
-	infos := make(map[string]infoResult) // host id to info output
+	infos := make(map[string]InfoResult) // host id to info output
 
 	var (
 		mut sync.Mutex

--- a/deployment/utils.go
+++ b/deployment/utils.go
@@ -8,9 +8,9 @@ import (
 	as "github.com/aerospike/aerospike-client-go/v6"
 )
 
-type infoResult map[string]string
+type InfoResult map[string]string
 
-func (ir infoResult) toInt(key string) (int, error) {
+func (ir InfoResult) toInt(key string) (int, error) {
 	val, ok := ir[key]
 	if !ok {
 		return 0, fmt.Errorf("field %s missing", key)
@@ -24,7 +24,7 @@ func (ir infoResult) toInt(key string) (int, error) {
 	return n, nil
 }
 
-func (ir infoResult) toString(key string) (string, error) {
+func (ir InfoResult) toString(key string) (string, error) {
 	val, ok := ir[key]
 	if !ok {
 		return "", fmt.Errorf("field %s missing", key)
@@ -33,7 +33,7 @@ func (ir infoResult) toString(key string) (string, error) {
 	return val, nil
 }
 
-func (ir infoResult) toBool(key string) (bool, error) {
+func (ir InfoResult) toBool(key string) (bool, error) {
 	val, ok := ir[key]
 	if !ok {
 		return false, fmt.Errorf("field %s missing", key)


### PR DESCRIPTION
Hi, Josh from the Aerospike Cloud (DBaaS) team here.

I'm making this PR to fulfill a few requirements we have:

1. We want the ability to run arbitrary `asinfo` commands from our code. Exporting this `GetInfoOnHosts()` method will allow us to do so. This also requires exporting `InfoResult`
2. This PR includes modification to `infoOnHosts()` to return infos that we were able to fetch even if the asinfo command failed on one or more hosts. This will allow us to get info on hosts that are healthy even if part of the cluster is not. I've looked through the methods that use `infoOnHosts()` in this library and I believe this change is compatible with current use cases.

Feel free to message me on Slack with any questions about this PR