### PR TITLE
fix panic and dc config for dc.name = ""

### DIFF
--- a/info/as_parser.go
+++ b/info/as_parser.go
@@ -44,10 +44,9 @@ const (
 	// 1. string values which are not commands
 	// 2. string values which are used to generate other commands
 	// 3. string values which are both command and constant
-	constStatXDRPre50 = "statistics/xdr" // StatXdr
-	constStatXDR      = "get-stats:context=xdr"
-	constStatNS       = "namespace/" // StatNamespace
-	constStatDCpre50  = "dc/"        // statDC
+	constStatXDRPre50 = "statistics/xdr" // StatXdr, there is no equivalent command in 5.0
+	constStatNS       = "namespace/"     // StatNamespace
+	constStatDCpre50  = "dc/"            // statDC
 	constStatDC       = "get-stats:context=xdr;dc="
 	constStatSet      = "sets/"      // StatSets
 	constStatBin      = "bins/"      // StatBins
@@ -498,7 +497,7 @@ func (info *AsInfo) createCmdList(
 }
 
 func (info *AsInfo) createStatCmdList(m map[string]string) []string {
-	cmdList := []string{ConstStat, constStatXDR, constStatNSNames, constStatDCNames}
+	cmdList := []string{ConstStat, constStatXDRPre50, constStatNSNames, constStatDCNames}
 
 	nsNames := getNames(m[constStatNSNames])
 	for _, ns := range nsNames {
@@ -899,7 +898,7 @@ func parseStatInfo(rawMap map[string]string) lib.Stats {
 	statMap := make(lib.Stats)
 
 	statMap["service"] = parseBasicInfo(rawMap[ConstStat])
-	statMap["xdr"] = parseBasicInfo(rawMap[constStatXDR])
+	statMap["xdr"] = parseBasicInfo(rawMap[constStatXDRPre50])
 	statMap["dc"] = parseAllDcStats(rawMap)
 	statMap["namespace"] = parseAllNsStats(rawMap)
 

--- a/info/as_parser.go
+++ b/info/as_parser.go
@@ -44,9 +44,10 @@ const (
 	// 1. string values which are not commands
 	// 2. string values which are used to generate other commands
 	// 3. string values which are both command and constant
-	constStatXDRPre50 = "statistics/xdr" // StatXdr, there is no equivalent command in 5.0
-	constStatNS       = "namespace/"     // StatNamespace
-	constStatDCpre50  = "dc/"            // statDC
+	constStatXDRPre50 = "statistics/xdr" // StatXdr
+	constStatXDR      = "get-stats:context=xdr"
+	constStatNS       = "namespace/" // StatNamespace
+	constStatDCpre50  = "dc/"        // statDC
 	constStatDC       = "get-stats:context=xdr;dc="
 	constStatSet      = "sets/"      // StatSets
 	constStatBin      = "bins/"      // StatBins
@@ -636,7 +637,11 @@ func (info *AsInfo) createXDRConfigCmdList(build string, m map[string]string) ([
 	rawNames, ok := xdrConfig[constStatDCNames].(string)
 
 	if ok {
-		dcNames = strings.Split(rawNames, ",")
+		if rawNames == "" {
+			dcNames = []string{}
+		} else {
+			dcNames = strings.Split(rawNames, ",")
+		}
 	} else {
 		dcNames = []string{}
 	}
@@ -697,6 +702,10 @@ func (info *AsInfo) createXDRConfigCmdList(build string, m map[string]string) ([
 
 // createDCConfigCmdList creates get-config command for DC
 func (info *AsInfo) createDCNamespaceConfigCmdList(dc string, namespaces ...string) []string {
+	if dc == "" {
+		return nil
+	}
+
 	cmdList := make([]string, 0, len(namespaces))
 
 	for _, ns := range namespaces {
@@ -898,7 +907,7 @@ func parseStatInfo(rawMap map[string]string) lib.Stats {
 	statMap := make(lib.Stats)
 
 	statMap["service"] = parseBasicInfo(rawMap[ConstStat])
-	statMap["xdr"] = parseBasicInfo(rawMap[constStatXDRPre50])
+	statMap["xdr"] = parseBasicInfo(rawMap[constStatXDR])
 	statMap["dc"] = parseAllDcStats(rawMap)
 	statMap["namespace"] = parseAllNsStats(rawMap)
 

--- a/info/as_parser_test.go
+++ b/info/as_parser_test.go
@@ -186,12 +186,12 @@ func (s *AsParserTestSuite) TestAsInfoGetAsConfigXDR5Disabled() {
 	// Call GetAsInfo with the input from the test case
 	s.mockConn.EXPECT().RequestInfo([]string{"namespaces", "dcs", "sindex/", "logs", "build"}).Return(coreInfoResp, nil)
 	s.mockConn.EXPECT().RequestInfo([]string{"get-config:context=xdr"}).Return(map[string]string{"get-config:context=xdr": "dcs=;src-id=0;trace-sample=0"}, nil)
+
 	expected := lib.Stats{"xdr": lib.Stats{
 		"src-id":       int64(0),
 		"trace-sample": int64(0),
 		"dcs":          lib.Stats{},
 	}}
-
 	result, err := s.asinfo.GetAsConfig(context)
 
 	s.Assert().Nil(err)

--- a/info/as_parser_test.go
+++ b/info/as_parser_test.go
@@ -32,7 +32,7 @@ func (s *AsParserTestSuite) SetupTest() {
 	s.asinfo = NewAsInfoWithConnFactory(logr.Discard(), host, policy, mockConnFact)
 }
 
-func (s *AsParserTestSuite) TestAsInfoRequestInfo() {
+func (s *AsParserTestSuite) TestAsInfoGetAsConfig() {
 	testCases := []struct {
 		context      string
 		coreInfoResp map[string]string
@@ -149,7 +149,7 @@ func (s *AsParserTestSuite) TestAsInfoRequestInfo() {
 	}
 }
 
-func (s *AsParserTestSuite) TestAsInfoRequestInfoXDR5() {
+func (s *AsParserTestSuite) TestAsInfoGetAsConfigXDR5Enabled() {
 	context := "xdr"
 	coreInfoResp := map[string]string{"build": "5.0.0.0"}
 
@@ -171,6 +171,25 @@ func (s *AsParserTestSuite) TestAsInfoRequestInfoXDR5() {
 				"bar": lib.Stats{"enabled": true, "bin-policy": "all", "compression-level": int64(1), "compression-threshold": int64(128), "delay-ms": int64(0), "enable-compression": false, "forward": false, "hot-key-ms": int64(100), "ignored-bins": ""},
 			}},
 		},
+	}}
+
+	result, err := s.asinfo.GetAsConfig(context)
+
+	s.Assert().Nil(err)
+	s.Assert().Equal(expected, result)
+}
+
+func (s *AsParserTestSuite) TestAsInfoGetAsConfigXDR5Disabled() {
+	context := "xdr"
+	coreInfoResp := map[string]string{"build": "5.0.0.0"}
+
+	// Call GetAsInfo with the input from the test case
+	s.mockConn.EXPECT().RequestInfo([]string{"namespaces", "dcs", "sindex/", "logs", "build"}).Return(coreInfoResp, nil)
+	s.mockConn.EXPECT().RequestInfo([]string{"get-config:context=xdr"}).Return(map[string]string{"get-config:context=xdr": "dcs=;src-id=0;trace-sample=0"}, nil)
+	expected := lib.Stats{"xdr": lib.Stats{
+		"src-id":       int64(0),
+		"trace-sample": int64(0),
+		"dcs":          lib.Stats{},
 	}}
 
 	result, err := s.asinfo.GetAsConfig(context)


### PR DESCRIPTION
constStatXDR on line 501 of as_parser.go was causing a panic because `get-stats:context=xdr` is not a valid info command. The logic for getting all stats still needs to be updated to support xdr5 and pre xdr5 server versions.

Additional logic was added to not make requests for dc configs if no xdr dc configs are configured. This will solve a problem where the Generate() call returns an xdr.dc.name = ""