### PR TITLE
Bugfix:[TOOLS-3046] fix namespace key in logging section

### DIFF
--- a/asconfig/conffilewriter.go
+++ b/asconfig/conffilewriter.go
@@ -14,6 +14,8 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/aerospike/aerospike-management-lib/info"
+
 	sets "github.com/deckarep/golang-set/v2"
 	"github.com/go-logr/logr"
 
@@ -125,7 +127,7 @@ func writeSpecialListSection(
 	indent int,
 ) {
 	section = SingularOf(section)
-	if section == "logging" {
+	if section == info.ConfigLoggingContext {
 		writeLogSection(log, buf, section, confList, indent)
 		return
 	}

--- a/asconfig/conffilewriter.go
+++ b/asconfig/conffilewriter.go
@@ -14,12 +14,11 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/aerospike/aerospike-management-lib/info"
-
 	sets "github.com/deckarep/golang-set/v2"
 	"github.com/go-logr/logr"
 
 	lib "github.com/aerospike/aerospike-management-lib"
+	"github.com/aerospike/aerospike-management-lib/info"
 )
 
 const (

--- a/asconfig/constants.go
+++ b/asconfig/constants.go
@@ -1,6 +1,9 @@
 package asconfig
 
-type Operation string
+type (
+	Operation string
+	Format    string
+)
 
 // All the aerospike config related keys
 const (
@@ -38,4 +41,8 @@ const (
 	Add    Operation = "add"
 	Remove Operation = "remove"
 	Update Operation = "update"
+
+	Invalid    Format = ""
+	YAML       Format = "yaml"
+	AeroConfig Format = "asconfig"
 )

--- a/asconfig/loader.go
+++ b/asconfig/loader.go
@@ -1,0 +1,274 @@
+package asconfig
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/go-logr/logr"
+	"gopkg.in/yaml.v3"
+
+	lib "github.com/aerospike/aerospike-management-lib"
+	"github.com/aerospike/aerospike-management-lib/info"
+)
+
+var ErrInvalidFormat = fmt.Errorf("invalid config format")
+
+func NewASConfigFromBytes(log logr.Logger, src []byte, srcFmt Format) (*AsConfig, error) {
+	var (
+		err error
+		cfg *AsConfig
+	)
+
+	switch srcFmt {
+	case YAML:
+		cfg, err = loadYAML(log, src)
+	case AeroConfig:
+		cfg, err = loadAsConf(log, src)
+	case Invalid:
+		return nil, fmt.Errorf("%w %s", ErrInvalidFormat, srcFmt)
+	default:
+		return nil, fmt.Errorf("%w %s", ErrInvalidFormat, srcFmt)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	// recreate the management lib config
+	// with a sorted config map so that output
+	// is always in the same order
+	cmap := cfg.ToMap()
+
+	if err = mutateMap(*cmap, []mapping{
+		sortLists,
+	}); err != nil {
+		return nil, fmt.Errorf("failed to sort config map: %w", err)
+	}
+
+	cfg, err = NewMapAsConfig(
+		log,
+		*cmap,
+	)
+
+	return cfg, err
+}
+
+func loadYAML(log logr.Logger, src []byte) (*AsConfig, error) {
+	var data map[string]any
+
+	err := yaml.Unmarshal(src, &data)
+	if err != nil {
+		return nil, err
+	}
+
+	c, err := NewMapAsConfig(
+		log,
+		data,
+	)
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize asconfig from yaml: %w", err)
+	}
+
+	return c, nil
+}
+
+func loadAsConf(log logr.Logger, src []byte) (*AsConfig, error) {
+	reader := bytes.NewReader(src)
+
+	// TODO: Why doesn't the management lib do the map mutation? FromConfFile
+	// implies it does.
+	c, err := FromConfFile(log, reader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse asconfig file: %w", err)
+	}
+
+	// the aerospike management lib parses asconfig files into
+	// a format that its validation rejects
+	// this is because the schema files are meant to
+	// validate the aerospike kubernetes operator's asconfig yaml format
+	// so we modify the map here to match that format
+	cmap := *c.ToMap()
+
+	// revert the mutation happened in logging section
+	logging := lib.DeepCopy(cmap[info.ConfigLoggingContext])
+
+	if err = mutateMap(cmap, []mapping{
+		typedContextsToObject,
+		ToPlural,
+	}); err != nil {
+		return nil, fmt.Errorf("failed to mutate config map: %w", err)
+	}
+
+	cmap[info.ConfigLoggingContext] = lib.DeepCopy(logging)
+	c, err = NewMapAsConfig(
+		log,
+		cmap,
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return c, nil
+}
+
+type configMap = lib.Stats
+
+// mapping functions get mapped to each key value pair in a management lib Stats map
+// m is the map that k and v came from
+type mapping func(k string, v any, m configMap) error
+
+// mutateMap maps functions to each key value pair in the management lib's Stats map
+// the functions are applied sequentially to each k,v pair.
+func mutateMap(in configMap, funcs []mapping) error {
+	var errs []error
+
+	keys := lib.GetKeys(in)
+	for idx := range keys {
+		v := in[keys[idx]]
+		switch v := v.(type) {
+		case configMap:
+			if err := mutateMap(v, funcs); err != nil {
+				errs = append(errs, fmt.Errorf("error in nested map for key %s: %w", keys[idx], err))
+			}
+		case []configMap:
+			for i, lv := range v {
+				if err := mutateMap(lv, funcs); err != nil {
+					errs = append(errs, fmt.Errorf("error in array element %d for key %s: %w", i, keys[idx], err))
+				}
+			}
+		}
+
+		for _, f := range funcs {
+			if err := f(keys[idx], in[keys[idx]], in); err != nil {
+				errs = append(errs, fmt.Errorf("error in mapping function for key %s: %w", keys[idx], err))
+			}
+		}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("errors in mutateMap: %v", errs)
+	}
+
+	return nil
+}
+
+/*
+typedContextsToObject converts config entries that the management lib
+parses as literal strings into the objects that the yaml schemas expect.
+NOTE: As of server 7.0 a context is required for storage-engine memory
+so it will no longer be a string. This is still needed for compatibility
+with older servers.
+Ex configMap
+
+	configMap{
+		"storage-engine": "memory"
+	}
+
+->
+
+	configMap{
+		"storage-engine": configMap{
+			"type": "memory"
+		}
+	}
+*/
+func typedContextsToObject(k string, _ any, m configMap) error {
+	if isTypedSection(k) {
+		v := m[k]
+		// if a typed context does not have a map value.
+		// then it's value is a string like "memory" or "flash"
+		// in order to make valid asconfig yaml we convert this context
+		// to a map where "type" maps to the value
+		if _, ok := v.(configMap); !ok {
+			m[k] = configMap{keyType: v}
+		}
+	}
+
+	return nil
+}
+
+/*
+sortLists sorts slices of config sections by the "name" or "type"
+key that the management lib adds to config list items
+Ex config:
+namespace ns2 {}
+namespace ns1 {}
+->
+namespace ns1 {}
+namespace ns2 {}
+
+Ex matching configMap
+
+	configMap{
+		"namespace": []configMap{
+			configMap{
+				"name": "ns2",
+			},
+			configMap{
+				"name": "ns1",
+			},
+		}
+	}
+
+->
+
+	configMap{
+		"namespace": []configMap{
+			configMap{
+				"name": "ns1",
+			},
+			configMap{
+				"name": "ns2",
+			},
+		}
+	}
+*/
+func sortLists(k string, v any, m configMap) error {
+	if v, ok := v.([]configMap); ok {
+		sort.Slice(v, func(i int, j int) bool {
+			iv, iok := v[i]["name"]
+			jv, jok := v[j]["name"]
+
+			// sections may also use the "type" field to identify themselves
+			if !iok {
+				iv, iok = v[i]["type"]
+			}
+
+			if !jok {
+				jv, jok = v[j]["type"]
+			}
+
+			// if i or both don't have id fields, consider them i >= j
+			if !iok {
+				return false
+			}
+
+			// if only j has an id field consider i < j
+			if !jok {
+				return true
+			}
+
+			iname := iv.(string)
+			jname := jv.(string)
+
+			gt := strings.Compare(iname, jname)
+
+			switch gt {
+			case 1:
+				return true
+			case -1, 0:
+				return false
+			default:
+				panic("unexpected gt value")
+			}
+		})
+
+		m[k] = v
+	}
+
+	return nil
+}

--- a/asconfig/utils.go
+++ b/asconfig/utils.go
@@ -14,6 +14,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/aerospike/aerospike-management-lib/info"
+
 	"github.com/go-logr/logr"
 
 	lib "github.com/aerospike/aerospike-management-lib"
@@ -629,7 +631,7 @@ func isSpecialListSection(section string) bool {
 	section = SingularOf(section)
 
 	switch section {
-	case "logging":
+	case info.ConfigLoggingContext:
 		return true
 
 	default:
@@ -858,6 +860,13 @@ func toConf(log logr.Logger, input map[string]interface{}) Conf {
 		}
 
 		handleValueType(log, k, v, result)
+
+		// Handle logging configuration as a special case.
+		// In the general Aerospike configuration, fields like "namespace" and "tls" are typically lists.
+		// However, in the logging section, these same fields are represented as strings instead.
+		if k == info.ConfigLoggingContext {
+			handleLoggingConfig(result)
+		}
 	}
 
 	return result
@@ -904,6 +913,23 @@ func handleValueType(log logr.Logger, key string, value interface{}, result Conf
 	default:
 		result[key] = value
 	}
+}
+
+func handleLoggingConfig(result Conf) {
+	loggings := result[info.ConfigLoggingContext].([]Conf)
+	for i := range loggings {
+		for k, v := range loggings[i] {
+			// Adjust the result for logging configuration by converting list-type fields to string-type,
+			// since logging expects fields like "namespace" and "tls" as strings instead of lists.
+			//nolint:gocritic //readability
+			switch val := v.(type) {
+			case []string:
+				loggings[i][k] = val[0]
+			}
+		}
+	}
+
+	result[info.ConfigLoggingContext] = loggings
 }
 
 // Add other helper functions here...
@@ -1065,7 +1091,24 @@ func GetFlatKey(tokens []string) string {
 	return strings.TrimSuffix(key, ".")
 }
 
-func ToPlural(k string, v any, m Conf) {
+/*
+ToPlural converts the keys that the management lib asconf parser
+parses as singular, to the plural keys that the yaml schemas expect
+Ex configMap
+	configMap{
+		"namespace": []configMap{
+			...
+		}
+	}
+->
+	configMap{
+		"namespaces": []configMap{
+			...
+		}
+	}
+*/
+
+func ToPlural(k string, v any, m configMap) error {
 	// convert asconfig fields/contexts that need to be plural
 	// in order to create valid asconfig yaml.
 	if plural := PluralOf(k); plural != k {
@@ -1075,7 +1118,7 @@ func ToPlural(k string, v any, m Conf) {
 		// than []string this might have to change.
 		if isListOrString(k) {
 			if _, ok := v.([]string); !ok {
-				return
+				return nil
 			}
 
 			if len(v.([]string)) == 1 {
@@ -1084,13 +1127,19 @@ func ToPlural(k string, v any, m Conf) {
 				// fields are actually scalars then overwrite the list
 				// with the single value
 				m[k] = v.([]string)[0]
-				return
+				return nil
 			}
 		}
 
 		delete(m, k)
 		m[plural] = v
+	} else if SingularOf(k) != k {
+		// if the plural is the same as the original
+		// plural config in input is not allowed
+		return fmt.Errorf("%s is not a valid config key", k)
 	}
+
+	return nil
 }
 
 // isListOrString returns true for special config fields that may be a

--- a/asconfig/utils.go
+++ b/asconfig/utils.go
@@ -14,11 +14,10 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/aerospike/aerospike-management-lib/info"
-
 	"github.com/go-logr/logr"
 
 	lib "github.com/aerospike/aerospike-management-lib"
+	"github.com/aerospike/aerospike-management-lib/info"
 )
 
 type sysproptype string
@@ -1108,7 +1107,7 @@ Ex configMap
 	}
 */
 
-func ToPlural(k string, v any, m configMap) error {
+func ToPlural(k string, v any, m Conf) error {
 	// convert asconfig fields/contexts that need to be plural
 	// in order to create valid asconfig yaml.
 	if plural := PluralOf(k); plural != k {

--- a/asconfig/utils.go
+++ b/asconfig/utils.go
@@ -915,7 +915,11 @@ func handleValueType(log logr.Logger, key string, value interface{}, result Conf
 }
 
 func handleLoggingConfig(result Conf) {
-	loggings := result[info.ConfigLoggingContext].([]Conf)
+	loggings, ok := result[info.ConfigLoggingContext].([]Conf)
+	if !ok {
+		return
+	}
+
 	for i := range loggings {
 		for k, v := range loggings[i] {
 			// Adjust the result for logging configuration by converting list-type fields to string-type,

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/aerospike/aerospike-management-lib
 
 go 1.23.0
 
-toolchain go1.23.6
+toolchain go1.23.8
 
 require (
 	github.com/aerospike/aerospike-client-go/v8 v8.2.1

--- a/utils.go
+++ b/utils.go
@@ -130,3 +130,12 @@ func ContainsString(list []string, ele string) bool {
 
 	return false
 }
+
+func GetKeys(m map[string]interface{}) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+
+	return keys
+}


### PR DESCRIPTION
Bug Fixes in this PR:

1. Fixed the asconfig validate command to correctly allow the namespace field in the logging section.
2. Updated asconfig validate to reject invalid plural forms like namespaces in the context section.
3. Resolved AKO schema validation issues for namespace and tls fields within the logging configuration.