### PR TITLE
fix: add missing max-record-size config to isSizeOrTime table tools-3074

### DIFF
--- a/asconfig/utils.go
+++ b/asconfig/utils.go
@@ -751,7 +751,7 @@ func isSizeOrTime(key string) (bool, humanize) {
 		"mounts-budget", "data-size",
 		"quarantine-allocations", "flush-size",
 		"post-write-cache", "indexes-memory-budget",
-		"sindex-stage-size":
+		"sindex-stage-size", "max-record-size":
 		return true, deHumanizeSize
 
 	default:


### PR DESCRIPTION
Needed to fix asconfig bug tools-3074.