### PR TITLE
fix: security and resources-leaks [KO-603]

### DIFF
--- a/asconfig/conffilereader.go
+++ b/asconfig/conffilereader.go
@@ -187,6 +187,14 @@ func writeConf(log logr.Logger, tok []string, conf Conf) error {
 	// More special Case handling
 	switch cfgName {
 	case "context":
+		if len(tok) < 3 {
+			log.Error(ErrConfigParse, "Logging context requires a context name and a level",
+				"config", cfgName, "token", tok,
+			)
+
+			return ErrConfigParse
+		}
+
 		conf[tok[1]] = tok[2]
 
 	default:

--- a/asconfig/conffilereader_test.go
+++ b/asconfig/conffilereader_test.go
@@ -1,0 +1,55 @@
+package asconfig
+
+import (
+	"bufio"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr"
+)
+
+func TestProcessLoggingContext(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected Conf
+		wantErr  bool
+	}{
+		{
+			name:     "context with level",
+			input:    "context any info",
+			expected: Conf{"any": "info"},
+		},
+		{
+			name:    "context without level",
+			input:   "context any",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			scanner := bufio.NewScanner(strings.NewReader(tc.input))
+
+			conf, err := process(logr.Discard(), scanner, Conf{})
+			if tc.wantErr {
+				if !errors.Is(err, ErrConfigParse) {
+					t.Fatalf("expected %v, got %v", ErrConfigParse, err)
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			for k, v := range tc.expected {
+				if conf[k] != v {
+					t.Errorf("expected %s=%v, got %v", k, v, conf[k])
+				}
+			}
+		})
+	}
+}

--- a/deployment/aeroinfo.go
+++ b/deployment/aeroinfo.go
@@ -10,10 +10,12 @@ import (
 
 // IsClusterAndStable returns true if the cluster formed by the set of hosts is stable.
 func IsClusterAndStable(log logr.Logger, policy *aero.ClientPolicy, allHosts []*HostConn) (bool, error) {
-	c, err := newCluster(log, policy, allHosts, allHosts)
+	c, err := newCluster(log, policy, allHosts)
 	if err != nil {
 		return false, fmt.Errorf("unable to create a cluster copy for running aeroinfo: %v", err)
 	}
+
+	defer c.close()
 
 	return c.IsClusterAndStable(getHostIDsFromHostConns(allHosts))
 }
@@ -21,50 +23,60 @@ func IsClusterAndStable(log logr.Logger, policy *aero.ClientPolicy, allHosts []*
 // InfoQuiesce quiesce hosts.
 func InfoQuiesce(log logr.Logger, policy *aero.ClientPolicy, allHosts, selectedHosts []*HostConn,
 	removedNamespaces []string) error {
-	c, err := newCluster(log, policy, allHosts, selectedHosts)
+	c, err := newCluster(log, policy, allHosts)
 	if err != nil {
 		return fmt.Errorf("unable to create a cluster copy for running aeroinfo: %v", err)
 	}
+
+	defer c.close()
 
 	return c.InfoQuiesce(getHostIDsFromHostConns(selectedHosts), getHostIDsFromHostConns(allHosts), removedNamespaces)
 }
 
 // InfoQuiesceUndo revert the effects of quiesce on the next recluster event
 func InfoQuiesceUndo(log logr.Logger, policy *aero.ClientPolicy, allHosts []*HostConn) error {
-	c, err := newCluster(log, policy, allHosts, allHosts)
+	c, err := newCluster(log, policy, allHosts)
 	if err != nil {
 		return fmt.Errorf("unable to create a cluster copy for running aeroinfo: %v", err)
 	}
+
+	defer c.close()
 
 	return c.InfoQuiesceUndo(getHostIDsFromHostConns(allHosts))
 }
 
 // InfoRecluster recluster hosts.
 func InfoRecluster(log logr.Logger, policy *aero.ClientPolicy, allHosts []*HostConn) error {
-	c, err := newCluster(log, policy, allHosts, allHosts)
+	c, err := newCluster(log, policy, allHosts)
 	if err != nil {
 		return fmt.Errorf("unable to create a cluster copy for running aeroinfo: %v", err)
 	}
+
+	defer c.close()
 
 	return c.InfoRecluster(getHostIDsFromHostConns(allHosts))
 }
 
 // GetQuiescedNodes returns a list of node hostIDs of all nodes that are pending_quiesce=true.
 func GetQuiescedNodes(log logr.Logger, policy *aero.ClientPolicy, allHosts []*HostConn) ([]string, error) {
-	c, err := newCluster(log, policy, allHosts, allHosts)
+	c, err := newCluster(log, policy, allHosts)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create a cluster copy for running aeroinfo: %v", err)
 	}
+
+	defer c.close()
 
 	return c.getQuiescedNodes(getHostIDsFromHostConns(allHosts))
 }
 
 // SetMigrateFillDelay sets the given migrate-fill-delay on all the given cluster nodes
 func SetMigrateFillDelay(log logr.Logger, policy *aero.ClientPolicy, allHosts []*HostConn, migrateFillDelay int) error {
-	c, err := newCluster(log, policy, allHosts, allHosts)
+	c, err := newCluster(log, policy, allHosts)
 	if err != nil {
 		return fmt.Errorf("unable to create a cluster copy for running aeroinfo: %v", err)
 	}
+
+	defer c.close()
 
 	return c.setMigrateFillDelay(migrateFillDelay, allHosts)
 }
@@ -72,10 +84,12 @@ func SetMigrateFillDelay(log logr.Logger, policy *aero.ClientPolicy, allHosts []
 // SetConfigCommandsOnHosts runs set config command for dynamic config on all the given cluster nodes
 func SetConfigCommandsOnHosts(log logr.Logger, policy *aero.ClientPolicy, allHosts, selectedHosts []*HostConn,
 	cmds []string) ([]string, error) {
-	c, err := newCluster(log, policy, allHosts, selectedHosts)
+	c, err := newCluster(log, policy, allHosts)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create a cluster copy for running aeroinfo: %v", err)
 	}
+
+	defer c.close()
 
 	return c.setConfigCommandsOnHosts(cmds, selectedHosts)
 }
@@ -83,20 +97,24 @@ func SetConfigCommandsOnHosts(log logr.Logger, policy *aero.ClientPolicy, allHos
 // GetClusterNamespaces gets the cluster namespaces
 func GetClusterNamespaces(log logr.Logger, policy *aero.ClientPolicy,
 	allHosts []*HostConn) (map[string][]string, error) {
-	c, err := newCluster(log, policy, allHosts, allHosts)
+	c, err := newCluster(log, policy, allHosts)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create a cluster copy for running aeroinfo: %v", err)
 	}
+
+	defer c.close()
 
 	return c.getClusterNamespaces(getHostIDsFromHostConns(allHosts))
 }
 
 func GetInfoOnHosts(log logr.Logger, policy *aero.ClientPolicy,
 	allHosts []*HostConn, cmd string) (map[string]InfoResult, error) {
-	c, err := newCluster(log, policy, allHosts, allHosts)
+	c, err := newCluster(log, policy, allHosts)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create a cluster copy for running aeroinfo: %v", err)
 	}
+
+	defer c.close()
 
 	return c.infoOnHosts(getHostIDsFromHostConns(allHosts), cmd)
 }

--- a/deployment/cluster.go
+++ b/deployment/cluster.go
@@ -18,8 +18,7 @@ const CmdNamespaces = "namespaces"
 
 // cluster represents an aerospike cluster
 type cluster struct {
-	allHosts      map[string]*host // all cluster hosts
-	selectedHosts map[string]*host // hosts on which script will work
+	allHosts map[string]*host // all cluster hosts
 
 	log logr.Logger
 }
@@ -58,22 +57,17 @@ func getHosts(policy *aero.ClientPolicy, conns []*HostConn) (
 	return hosts, nil
 }
 
-// NewCluster returns a new cluster for the hosts
-func newCluster(log logr.Logger, policy *aero.ClientPolicy, allConns, operableConns []*HostConn) (*cluster, error) {
+// NewCluster returns a new cluster for the hosts.
+// The caller must call close() on the returned cluster to release its connections.
+func newCluster(log logr.Logger, policy *aero.ClientPolicy, allConns []*HostConn) (*cluster, error) {
 	allHosts, err := getHosts(policy, allConns)
 	if err != nil {
 		return nil, err
 	}
 
-	selectedHosts, err := getHosts(policy, operableConns)
-	if err != nil {
-		return nil, err
-	}
-
 	c := cluster{
-		allHosts:      allHosts,
-		selectedHosts: selectedHosts,
-		log:           log,
+		allHosts: allHosts,
+		log:      log,
 	}
 
 	return &c, nil
@@ -81,20 +75,26 @@ func newCluster(log logr.Logger, policy *aero.ClientPolicy, allConns, operableCo
 
 // close the aerospike client connections and the ssh connections.
 func (c *cluster) close() {
-	for _, nd := range c.allHosts {
-		if err := nd.Close(); err != nil {
-			c.log.V(1).Info(
-				"Failed to close node connections", "node", nd, "err", err,
-			)
-		}
-	}
+	closeHosts(c.log, c.allHosts)
+}
 
-	for _, nd := range c.selectedHosts {
-		if err := nd.Close(); err != nil {
-			c.log.V(1).Info(
-				"Failed to close node connections", "node", nd, "err", err,
-			)
-		}
+func closeHosts(log logr.Logger, hosts map[string]*host) {
+	for _, nd := range hosts {
+		closeHost(log, nd)
+	}
+}
+
+func closeHostList(log logr.Logger, hosts []*host) {
+	for _, nd := range hosts {
+		closeHost(log, nd)
+	}
+}
+
+func closeHost(log logr.Logger, nd *host) {
+	if err := nd.Close(); err != nil {
+		log.V(1).Info(
+			"Failed to close node connections", "node", nd, "err", err,
+		)
 	}
 }
 

--- a/deployment/deployment.go
+++ b/deployment/deployment.go
@@ -49,6 +49,12 @@ func (asc *ASConn) RunInfo(
 	}
 	asinfo := info.NewAsInfo(asc.Log, &h, aerospikePolicy)
 
+	defer func() {
+		if err := asinfo.Close(); err != nil {
+			asc.Log.V(1).Info("Failed to close asinfo connection", "err", err)
+		}
+	}()
+
 	return asinfo.RequestInfo(command...)
 }
 

--- a/deployment/host.go
+++ b/deployment/host.go
@@ -76,6 +76,10 @@ func (n *host) Build() (string, error) {
 
 // Close closes all the open connections of the host.
 func (n *host) Close() error {
+	if n.asConnInfo == nil {
+		return nil
+	}
+
 	if n.asConnInfo.asInfo != nil {
 		if err := n.asConnInfo.asInfo.Close(); err != nil {
 			return fmt.Errorf(

--- a/deployment/strong_consistency.go
+++ b/deployment/strong_consistency.go
@@ -30,6 +30,8 @@ func ManageRoster(log logr.Logger, hostConns []*HostConn, policy *as.ClientPolic
 		return err
 	}
 
+	defer closeHostList(log, clHosts)
+
 	scNamespacesPerHost, isClusterSCEnabled, err := getSCNamespaces(clHosts)
 	if err != nil {
 		return err
@@ -143,6 +145,8 @@ func ValidateSCClusterState(log logr.Logger, hostConns []*HostConn, policy *as.C
 	if err != nil {
 		return err
 	}
+
+	defer closeHostList(log, clHosts)
 
 	scNamespacesPerHost, isClusterSCEnabled, err := getSCNamespaces(clHosts)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aerospike/aerospike-management-lib
 
-go 1.25.10
+go 1.25.12
 
 require (
 	github.com/aerospike/aerospike-client-go/v8 v8.7.0

--- a/info/as_parser.go
+++ b/info/as_parser.go
@@ -303,7 +303,6 @@ func (info *AsInfo) doInfo(commands ...string) (map[string]string, error) {
 			// The connection is unauthenticated, it must not be reused for
 			// sending commands on a retry.
 			info.conn.Close()
-			info.conn = nil
 
 			ae := &aero.AerospikeError{}
 			if errors.As(aerr, &ae) {

--- a/info/as_parser.go
+++ b/info/as_parser.go
@@ -300,11 +300,16 @@ func (info *AsInfo) doInfo(commands ...string) (map[string]string, error) {
 
 		aerr := info.conn.Login(info.policy)
 		if aerr != nil {
+			// The connection is unauthenticated, it must not be reused for
+			// sending commands on a retry.
+			info.conn.Close()
+			info.conn = nil
+
 			ae := &aero.AerospikeError{}
-			if errors.As(err, &ae) {
+			if errors.As(aerr, &ae) {
 				return nil, fmt.Errorf(
-					"failed to authenticate user `%s` in aerospike server: %v",
-					info.policy.User, ae.ResultCode,
+					"failed to authenticate user `%s` in aerospike server, result code %v: %w",
+					info.policy.User, ae.ResultCode, aerr,
 				)
 			}
 

--- a/info/as_parser_test.go
+++ b/info/as_parser_test.go
@@ -627,7 +627,8 @@ func TestNewAsInfo_NotAuthenticatedError(t *testing.T) {
 }
 
 // TestRequestInfoLoginFailure ensures that a connection which failed to log in is
-// closed and dropped, so that a retry does not send commands over it unauthenticated.
+// closed, so that a retry creates a fresh, re-authenticated connection instead of
+// sending commands over the unauthenticated one.
 func TestRequestInfoLoginFailure(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockConnFact := NewMockConnectionFactory(ctrl)
@@ -642,11 +643,12 @@ func TestRequestInfoLoginFailure(t *testing.T) {
 
 	defer func() { maxInfoRetries = prevRetries }()
 
-	// A new connection must be created and closed on every attempt. RequestInfo and
-	// IsConnected are not expected, calling either means the failed connection was reused.
+	// A new connection must be created and closed on every attempt. RequestInfo
+	// is not expected, calling it would mean the failed connection was reused.
 	mockConnFact.EXPECT().NewConnection(policy, host).Return(mockConn, nil).Times(retries)
 	mockConn.EXPECT().Login(policy).Return(loginErr).Times(retries)
 	mockConn.EXPECT().Close().Return().Times(retries)
+	mockConn.EXPECT().IsConnected().Return(false).AnyTimes()
 
 	asinfo := NewAsInfoWithConnFactory(logr.Discard(), host, policy, mockConnFact)
 
@@ -657,10 +659,6 @@ func TestRequestInfoLoginFailure(t *testing.T) {
 
 	if !errors.Is(err, loginErr) {
 		t.Errorf("Expected error %v, got %v", loginErr, err)
-	}
-
-	if asinfo.conn != nil {
-		t.Error("Expected the unauthenticated connection to be dropped")
 	}
 }
 

--- a/info/as_parser_test.go
+++ b/info/as_parser_test.go
@@ -626,6 +626,44 @@ func TestNewAsInfo_NotAuthenticatedError(t *testing.T) {
 	}
 }
 
+// TestRequestInfoLoginFailure ensures that a connection which failed to log in is
+// closed and dropped, so that a retry does not send commands over it unauthenticated.
+func TestRequestInfoLoginFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockConnFact := NewMockConnectionFactory(ctrl)
+	mockConn := NewMockConnection(ctrl)
+	policy := &aero.ClientPolicy{User: "admin"}
+	host := &aero.Host{}
+	loginErr := &aero.AerospikeError{ResultCode: 62}
+
+	retries := 2
+	prevRetries := maxInfoRetries
+	maxInfoRetries = retries
+
+	defer func() { maxInfoRetries = prevRetries }()
+
+	// A new connection must be created and closed on every attempt. RequestInfo and
+	// IsConnected are not expected, calling either means the failed connection was reused.
+	mockConnFact.EXPECT().NewConnection(policy, host).Return(mockConn, nil).Times(retries)
+	mockConn.EXPECT().Login(policy).Return(loginErr).Times(retries)
+	mockConn.EXPECT().Close().Return().Times(retries)
+
+	asinfo := NewAsInfoWithConnFactory(logr.Discard(), host, policy, mockConnFact)
+
+	res, err := asinfo.RequestInfo("statistics")
+	if res != nil {
+		t.Errorf("Expected nil response, got %v", res)
+	}
+
+	if !errors.Is(err, loginErr) {
+		t.Errorf("Expected error %v, got %v", loginErr, err)
+	}
+
+	if asinfo.conn != nil {
+		t.Error("Expected the unauthenticated connection to be dropped")
+	}
+}
+
 func TestParseNodeList(t *testing.T) {
 	testCases := []struct {
 		name     string

--- a/stats.go
+++ b/stats.go
@@ -436,8 +436,8 @@ func (s *SyncStats) GetMulti(names ...string) Stats {
 }
 
 func (s *SyncStats) Del(names ...string) {
-	s.mutex.RLock()
-	defer s.mutex.RUnlock()
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
 
 	s._Stats.Del(names...)
 }


### PR DESCRIPTION
Fixes applied to aerospike-management-lib following a manual security and resource-leak audit of the deployment, info, and asconfig packages, plus a govulncheck dependency scan.

**High**

- Fixed a systemic connection leak across all deployment package public APIs (aeroinfo.go, deployment.go, strong_consistency.go) where cluster/host connections were never closed, steadily exhausting client file descriptors and server-side proto-fd slots in reconcile-loop usage.
- Fixed info.doInfo retaining an open, unauthenticated connection after a login failure, which also allowed a subsequent retry to send commands over the still-unauthenticated socket.
- Removed the unused `selectedHosts` and corresponding connection objects. 
- Fixed a reachable crash (index-out-of-range) when parsing a malformed context line in an aerospike.conf file.
- Fixed SyncStats.Del mutating the underlying map while holding only a read lock, which could trigger a fatal, unrecoverable concurrent-map-write crash.

**Medium**

- Fixed dead-code login-error classification in doInfo caused by checking the wrong error variable, which made the auth-failure result-code branch permanently unreachable.
- Bumped the Go toolchain to 1.25.12, resolving two reachable standard-library CVEs (net/textproto, crypto/x509) flagged by govulncheck.